### PR TITLE
Allow stripping root groups from joined group names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,8 @@ Groups stored within Keycloak can be synchronized into OpenShift. The following 
 | `realm` | Realm to synchronize | | Yes |
 | `scope` | Scope for group synchronization. Options are `one` for one level or `sub` to include subgroups | `sub` | No |
 | `subGroupProcessing` | Controls how sub groups are processed. `flat` flattens the groups. `join` joins the group names with a configurable separator. | `flat` | No |
-| `subGroupJoinSeparator` | Separator to join group names if subGroupProcessing is set to join. | `""` | No |
+| `subGroupJoinSeparator` | List of top level groups to strip from group names if using `subGroupProcessing: join`. | `[]` | No |
+| `subGroupJoinStripRootGroups` | Separator to join group names if subGroupProcessing is set to join. | `""` | No |
 | `url` | URL Location for Keycloak | | Yes |
 
 

--- a/api/v1alpha1/groupsync_types.go
+++ b/api/v1alpha1/groupsync_types.go
@@ -203,6 +203,11 @@ type KeycloakProvider struct {
 	// +kubebuilder:validation:Optional
 	SubGroupJoinSeparator string `json:"subGroupJoinSeparator,omitempty"`
 
+	// SubGroupJoinStripGroups controls whether to strip the root groups given by name.
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Controls whether to strip the root groups given by name."
+	// +kubebuilder:validation:Optional
+	SubGroupJoinStripRootGroups []string `json:"subGroupJoinStripRootGroups,omitempty"`
+
 	// URL is the location of the Keycloak server
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Keycloak URL",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	// +kubebuilder:validation:Required

--- a/config/crd/bases/redhatcop.redhat.io_groupsyncs.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_groupsyncs.yaml
@@ -251,6 +251,11 @@ spec:
                           subGroupJoinSeparator:
                             description: SubGroupJoinSeparator represents the separator to join group names if subGroupProcessing is set to join
                             type: string
+                          subGroupJoinStripRootGroups:
+                            description: SubGroupJoinStripGroups controls whether to strip the root groups given by name.
+                            items:
+                              type: string
+                            type: array
                           subGroupProcessing:
                             description: SubGroupProcessing controls how sub groups are processed. Flat flattens the groups and is the default. Groups "hidden-fox" with child "staff" and "purple-bat" with child "staff" become "hidden-fox", "purple-bat", "staff". Join joins the group names with a configurable separator. Groups "hidden-fox" with child "staff" and "purple-bat" with child "staff" become "hidden-fox", "hidden-fox/staff", "purple-bat", "purple-bat/staff".
                             enum:

--- a/pkg/syncer/keycloak.go
+++ b/pkg/syncer/keycloak.go
@@ -179,10 +179,11 @@ func (k *KeycloakSyncer) Sync() ([]userv1.Group, error) {
 	mapper := KeycloakGroupMapper{
 		GetGroupMembers: k.getGroupMembers,
 
-		AllowedGroups:         k.Provider.Groups,
-		Scope:                 k.Provider.Scope,
-		SubGroupProcessing:    k.Provider.SubGroupProcessing,
-		SubGroupJoinSeparator: k.Provider.SubGroupJoinSeparator,
+		SubGroupJoinStripRootGroups: k.Provider.SubGroupJoinStripRootGroups,
+		AllowedGroups:               k.Provider.Groups,
+		Scope:                       k.Provider.Scope,
+		SubGroupProcessing:          k.Provider.SubGroupProcessing,
+		SubGroupJoinSeparator:       k.Provider.SubGroupJoinSeparator,
 	}
 
 	ocpGroups, err := mapper.Map(groups)


### PR DESCRIPTION
This PR allows syncing groups under a root group:

#### With:

```yaml
apiVersion: redhatcop.redhat.io/v1alpha1
kind: GroupSync
metadata:
  name: keycloak-groupsync
spec:
  providers:
  - name: keycloak
    keycloak:
[...]
      groups:
      - Organizations
      subGroupProcessing: join
      subGroupJoinSeparator: "+"
      subGroupJoinStripRootGroups:
      - Organizations
```

#### Groups:

```
Organizations
\-> my-org
    \-> my-team
Customers
\-> my-cust
```

#### Become

```
my-org
my-org+my-team
```

