### PR TITLE
Fix group members disappearing on KC timeouts/errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ controller-gen: ## Download controller-gen locally if necessary.
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.2)
 
 #go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
@@ -194,7 +194,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef
@@ -264,16 +264,16 @@ helmchart: kustomize
 	$(KUSTOMIZE) build ./config/crd > ./charts/${OPERATOR_NAME}/crds/crds.yaml
 	version=${VERSION} envsubst < ./config/helmchart/Chart.yaml.tpl  > ./charts/${OPERATOR_NAME}/Chart.yaml
 	version=${VERSION} image_repo=$${IMG%:*} envsubst < ./config/helmchart/values.yaml.tpl  > ./charts/${OPERATOR_NAME}/values.yaml
-	helm lint ./charts/${OPERATOR_NAME}	
+	helm lint ./charts/${OPERATOR_NAME}
 
 helmchart-repo: helmchart
 	mkdir -p ${HELM_REPO_DEST}/${OPERATOR_NAME}
 	helm package -d ${HELM_REPO_DEST}/${OPERATOR_NAME} ./charts/${OPERATOR_NAME}
 	helm repo index --url ${CHART_REPO_URL} ${HELM_REPO_DEST}
 
-helmchart-repo-push: helmchart-repo	
+helmchart-repo-push: helmchart-repo
 	git -C ${HELM_REPO_DEST} add .
 	git -C ${HELM_REPO_DEST} status
 	git -C ${HELM_REPO_DEST} commit -m "Release ${VERSION}"
-	git -C ${HELM_REPO_DEST} push origin "gh-pages"	
-	
+	git -C ${HELM_REPO_DEST} push origin "gh-pages"
+

--- a/pkg/syncer/keycloak_group_mapper.go
+++ b/pkg/syncer/keycloak_group_mapper.go
@@ -35,7 +35,10 @@ func (k *KeycloakGroupMapper) Map(groups []*gocloak.Group) ([]userv1.Group, erro
 	for _, group := range groups {
 
 		if _, groupFound := k.cachedGroups[*group.ID]; !groupFound {
-			k.processGroupsAndMembers(group, nil, k.Scope, k.SubGroupProcessing, k.SubGroupJoinSeparator)
+			err := k.processGroupsAndMembers(group, nil, k.Scope, k.SubGroupProcessing, k.SubGroupJoinSeparator)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -158,7 +161,10 @@ func (k *KeycloakGroupMapper) processGroupsAndMembers(group, parentGroup *gocloa
 	if redhatcopv1alpha1.SubSyncScope == scope {
 		for _, subGroup := range group.SubGroups {
 			if _, subGroupFound := k.cachedGroups[*subGroup.ID]; !subGroupFound {
-				k.processGroupsAndMembers(subGroup, group, scope, subGroupProcessing, subGroupJoinSeparator)
+				err := k.processGroupsAndMembers(subGroup, group, scope, subGroupProcessing, subGroupJoinSeparator)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Ignoring non-200 errors and timeouts from the `GoCloak.GetGroupMembers` Keycloak API call can lead to groups without members in the cluster.